### PR TITLE
Attach submissions to user emails

### DIFF
--- a/metadata/config/service.json
+++ b/metadata/config/service.json
@@ -1,6 +1,7 @@
 {
   "_id": "service",
   "_type": "config.service",
+  "attachUserSubmission": true,
   "code": "DSD-LF",
   "emailInputNameTeam": "elliott.bouher@digital.justice.gov.uk",
   "emailInputNameUser": "leaver_email",


### PR DESCRIPTION
New functionality introduced in the Runner will stop sending user attachments.
Preserve this functionality for now.