### PR TITLE
Use email component for user inputted email field

### DIFF
--- a/metadata/page/page.leaver-details.json
+++ b/metadata/page/page.leaver-details.json
@@ -6,6 +6,7 @@
       "_id": "page.leaver-details--date.leave-date",
       "_type": "date",
       "label": "Leave date",
+      "legend": "Leave date",
       "name": "leave_date"
     },
     {
@@ -15,8 +16,8 @@
       "name": "leaver_name"
     },
     {
-      "_id": "page.leaver-details--text.email",
-      "_type": "text",
+      "_id": "page.leaver-details--email.email",
+      "_type": "email",
       "errors": {
         "pattern": {
           "inline": "Please enter a valid email"


### PR DESCRIPTION
The leavers email field was not using the email component previously
therefore there was no validation on what the user inputted. This has
resulted in some bad email addresses being entered which cause
submission failures.

Swap it out for the email component field which has some validtion on
it. Obviously we cannot check whether the email is actually correct, but
we can at least check it is formatted correctly.

<img width="700" alt="Screenshot 2020-04-22 at 16 40 27" src="https://user-images.githubusercontent.com/3466862/80003251-a7115000-84b8-11ea-8bec-c9e0ea071e2d.png">

Also the Leavers date component was missing a legend, so add that in.